### PR TITLE
Add new comptroller implementation fn to update uni compAddress

### DIFF
--- a/packages/hardhat-ts/contracts/ComptrollerG7.sol
+++ b/packages/hardhat-ts/contracts/ComptrollerG7.sol
@@ -71,6 +71,11 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
     /// @notice Emitted when COMP is granted by admin
     event CompGranted(address recipient, uint amount);
 
+    /**
+    * @notice Emits updated _compAddress in unitroller storage
+    */
+    event NewCompAddress(address oldAddress, address newAddress);
+
     /// @notice The initial COMP index for a market
     uint224 public constant compInitialIndex = 1e36;
 
@@ -1363,5 +1368,16 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
      */
     function getCompAddress() public view returns (address) {
         return _compAddress;
+    }
+
+    function updateCompAddress() public {
+        require(msg.sender == admin, "can only be called by admin");
+        (bool success, bytes memory compAddressEncoded) = comptrollerImplementation.call(abi.encodeWithSignature("getCompAddress()"));
+        require(success, "failed at comptrollerImplementation.getCompAddress()");
+        address newCompAddress = abi.decode(compAddressEncoded, (address));
+        if (newCompAddress != address(0) && _compAddress != newCompAddress) {
+            emit NewCompAddress(_compAddress, newCompAddress);
+            _compAddress = newCompAddress;
+        }
     }
 }

--- a/packages/hardhat-ts/contracts/Governance/Comp.sol
+++ b/packages/hardhat-ts/contracts/Governance/Comp.sol
@@ -12,7 +12,7 @@ contract Comp {
   uint8 public constant decimals = 18;
 
   /// @notice Total number of tokens in circulation
-  uint256 public constant totalSupply = 25000000e18; // 25 million bdAMM
+  uint256 public constant totalSupply = 250000000e18; // 250 million bdAMM
 
   /// @notice Allowance amounts on behalf of others
   mapping(address => mapping(address => uint96)) internal allowances;

--- a/packages/hardhat-ts/deploy/02_deploy_unitroller.ts
+++ b/packages/hardhat-ts/deploy/02_deploy_unitroller.ts
@@ -27,10 +27,15 @@ const func: DeployFunction = async (hre: THardhatRuntimeEnvironmentExtended) => 
   if (currentImplementation === Comptroller.address) {
     console.log('skipping Unitroller._setPendingImplementation; already set');
   } else {
+    // updating comptroller implementation
     console.log(`setting Unitroller comptroller implementation to ${Comptroller.address}`)
     await (await Unitroller._setPendingImplementation(Comptroller.address)).wait();
     console.log(`Comptroller: becoming Unitroller at ${Unitroller.address}`);
     await (await Comptroller._become(Unitroller.address)).wait();
+    if (await Comptroller.getCompAddress() !== await (Comptroller.attach(Unitroller.address).getCompAddress())) {
+      console.log(`Updating comp address to ${await Comptroller.getCompAddress()}`);
+      await (await Comptroller.attach(Unitroller.address).updateCompAddress()).wait();
+    }
   }
 };
 export default func;


### PR DESCRIPTION
Add an admin-only `updateCompAddress()` function to ComptrollerG7.sol (to be proxy-called through the unitroller). This will correctly set the `_compAddress` storage variable (defined in the unitroller), and, if the unitroller accepts a new comptroller implementation which was deployed with a different `_compAddress`, the unitroller `_compAddress` can be updated by the admin.