### PR TITLE
Patch comptroller contract with hardcoded BDAMM address

### DIFF
--- a/packages/hardhat-ts/contracts/ComptrollerG7.sol
+++ b/packages/hardhat-ts/contracts/ComptrollerG7.sol
@@ -1361,7 +1361,7 @@ contract ComptrollerG7 is ComptrollerV5Storage, ComptrollerInterface, Comptrolle
      * @notice Return the address of the COMP token
      * @return The address of COMP
      */
-    function getCompAddress() public view returns (address) {
-        return _compAddress;
+    function getCompAddress() public pure returns (address) {
+        return 0x0000000000000000000000000000000000000000;
     }
 }

--- a/packages/hardhat-ts/contracts/Governance/Comp.sol
+++ b/packages/hardhat-ts/contracts/Governance/Comp.sol
@@ -12,7 +12,7 @@ contract Comp {
   uint8 public constant decimals = 18;
 
   /// @notice Total number of tokens in circulation
-  uint256 public constant totalSupply = 25000000e18; // 25 million bdAMM
+  uint256 public constant totalSupply = 250000000e18; // 250 million bdAMM
 
   /// @notice Allowance amounts on behalf of others
   mapping(address => mapping(address => uint96)) internal allowances;

--- a/packages/hardhat-ts/deploy/01_deploy_comptroller.ts
+++ b/packages/hardhat-ts/deploy/01_deploy_comptroller.ts
@@ -1,24 +1,34 @@
+import fs from 'fs';
+
 import { ethers } from 'hardhat';
 import { DeployFunction } from 'hardhat-deploy/types';
 import { THardhatRuntimeEnvironmentExtended } from 'helpers/types/THardhatRuntimeEnvironmentExtended';
 
-// const adminAddress = process.env.ADMIN_ADDRESS;
-// if (typeof adminAddress !== 'string' || adminAddress.length !== 42) {
-//   console.error('ADMIN_ADDRESS environment not supplied');
-//   process.exit(1);
-// }
+const PATH_TO_COMPTROLLER_SOL = '../hardhat-ts/contracts/ComptrollerG7.sol';
 
 const func: DeployFunction = async (hre: THardhatRuntimeEnvironmentExtended) => {
   const { getNamedAccounts, deployments } = hre;
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
-  const Comp = await ethers.getContract('BDAMM');
-  await deploy('ComptrollerImplementation', {
-    contract: 'ComptrollerG7',
-    from: deployer,
-    log: true,
-    args: [Comp.address],
-  });
+  const BDAMM = await ethers.getContract('BDAMM');
+  // If BDAMM was deployed/redeployed in the previous step, replace address in contract and exit
+  const comptrollerContractCode = fs.readFileSync(PATH_TO_COMPTROLLER_SOL).toString();
+  const comptrollerContractCodeUpdated = comptrollerContractCode
+    .replace(/return 0x[a-fA-F0-9]{40};/, `return ${BDAMM.address};`);
+  if (comptrollerContractCode === comptrollerContractCodeUpdated) {
+    await deploy('ComptrollerImplementation', {
+      contract: 'ComptrollerG7',
+      from: deployer,
+      log: true,
+      args: [BDAMM.address],
+    });
+  } else {
+    fs.writeFileSync(PATH_TO_COMPTROLLER_SOL, comptrollerContractCodeUpdated);
+    console.error(`Updating ComptrollerG7.sol with new BDAMM address ${BDAMM.address}.`);
+    console.error('Run `yarn deploy` again to trigger rebuild and deploy');
+    console.error("IMPORTANT: If this is a mainnet deployment, the updated ComptrollerG7.sol should be committed\nafter re-running to prevent redeploys");
+    process.exit(1);
+  }
 };
 export default func;
 func.tags = ['core'];

--- a/packages/hardhat-ts/deploy/10_deploy_oracle.ts
+++ b/packages/hardhat-ts/deploy/10_deploy_oracle.ts
@@ -87,6 +87,7 @@ const func: DeployFunction = async (hre: THardhatRuntimeEnvironmentExtended) => 
     const currentPrice = priceData[coingeckoId].usd;
     if (Math.abs((previousPrice - currentPrice)/currentPrice) > 0.25) {
       // Set all prices again if any price is more than 25% away from the previous price
+      console.log(`${symbol}: old price`, previousPrice, 'current price', currentPrice)
       priceChanged = true;
     } else {
       console.log(`detected similar price for ${symbol} within 25% of current:\nPrevious: ${previousPrice}\nCurrent: ${currentPrice}`);


### PR DESCRIPTION
This allows us to set the BDAMM address directly in the ComptrollerG7.sol file, and manually patches it and enforces contract rebuilding when the BDAMM address changes